### PR TITLE
Adding attribute to handle the display of page number

### DIFF
--- a/phantomjs.php
+++ b/phantomjs.php
@@ -15,7 +15,8 @@ function generate($atts,$content=null,$shortcode){
 		'output_file'=>'',
 		'format'=>'A3',
 		'orientation' =>'portrait',
-		'margin'=>'0cm'
+		'margin'=>'0cm',
+		'show_page_number'=>'yes'
 		), $atts) );
 	
 	/*Needed to load required files from JonnyW-PhantomJs Library*/
@@ -53,9 +54,10 @@ function generate($atts,$content=null,$shortcode){
     $request->setFormat($format);
     $request->setOrientation($orientation);
     $request->setMargin($margin);
-    $request->setRepeatingHeader('<span style="float:right; font-size: 9px;">%pageNum% / %pageTotal%</span>');
-    $request->setRepeatingFooter('<span style="float:right; font-size: 9px;">%pageNum% / %pageTotal%</span>');
-
+    if($show_page_number == 'yes'){
+	    $request->setRepeatingHeader('<span style="float:right; font-size: 9px;">%pageNum% / %pageTotal%</span>');
+	    $request->setRepeatingFooter('<span style="float:right; font-size: 9px;">%pageNum% / %pageTotal%</span>');
+    }
     /** 
      * @see JonnyW\PhantomJs\Http\Response 
      **/


### PR DESCRIPTION
Description : 
Support for displaying page number as optional. 

Default behavior : Page number will be displayed on the top and bottom of the page in the format 1/10

If you dont need page number on the generated pdf, use as shown below : 
[phatomjs.generate  show_page_number="no" ...... /]